### PR TITLE
[Feature] add EnsureSuccessStatusCode helper and EnsureSuccessAsync client overloads; fixes #23

### DIFF
--- a/ArgusTransfer.Tests/Client/ArgusClientTestFixture.cs
+++ b/ArgusTransfer.Tests/Client/ArgusClientTestFixture.cs
@@ -52,6 +52,40 @@ namespace ArgusTransfer.Tests.Client
             this.responseSerializer = new ArgusResponseSerializer();
         }
 
+        /// <summary>
+        /// Runs a single-shot fake pipe server that reads one request, optionally validates it,
+        /// and writes back a response with the given status code and body
+        /// </summary>
+        /// <param name="pipeName">The name of the pipe to listen on</param>
+        /// <param name="validateRequest">Optional callback invoked with the deserialized request for assertions</param>
+        /// <param name="responseStatus">The status code to return to the client</param>
+        /// <param name="responseBody">The optional response body</param>
+        /// <returns>A task that completes once the server has written its response</returns>
+        private Task RunFakeServerAsync(string pipeName, Action<ArgusRequest> validateRequest, ArgusStatusCode responseStatus, string responseBody = null)
+        {
+            return Task.Run(async () =>
+            {
+                using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut);
+                await server.WaitForConnectionAsync();
+
+                var reader = new StreamReader(server, new UTF8Encoding(false));
+                var writer = new StreamWriter(server, new UTF8Encoding(false)) { AutoFlush = false };
+
+                var request = await this.requestSerializer.ReadAsync(reader, CancellationToken.None);
+
+                validateRequest?.Invoke(request);
+
+                var response = new ArgusResponse
+                {
+                    CorrelationToken = request.CorrelationToken,
+                    StatusCode = responseStatus,
+                    Body = responseBody
+                };
+
+                this.responseSerializer.Write(writer, response);
+            });
+        }
+
         [Test]
         public async Task Verify_that_SendAsync_round_trips_request_and_response()
         {
@@ -737,6 +771,284 @@ namespace ArgusTransfer.Tests.Client
             Assert.That(exception.StatusCode, Is.EqualTo(ArgusStatusCode.NotFound));
             Assert.That(exception.ReasonPhrase, Is.EqualTo(ArgusStatusCode.NotFound.ToReasonPhrase()));
             Assert.That(exception.ResponseBody, Is.EqualTo("missing"));
+        }
+
+        [Test]
+        public async Task Verify_that_SendEnsureSuccessAsync_forwards_request_and_returns_response()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.PUT));
+                Assert.That(r.Route, Is.EqualTo("/items"));
+            }, ArgusStatusCode.Ok, "ok");
+
+            using var client = new ArgusClient(pipeName);
+
+            var response = await client.SendEnsureSuccessAsync(new ArgusRequest { Verb = ArgusVerb.PUT, Route = "/items" });
+
+            await serverTask;
+            Assert.That(response.Body, Is.EqualTo("ok"));
+        }
+
+        [Test]
+        public async Task Verify_that_GetEnsureSuccessAsync_with_query_parameters_sends_query_parameters()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.GET));
+                Assert.That(r.QueryParameters["key"], Is.EqualTo("value"));
+            }, ArgusStatusCode.Ok);
+
+            using var client = new ArgusClient(pipeName);
+
+            var response = await client.GetEnsureSuccessAsync("/items", new Dictionary<string, string> { { "key", "value" } });
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
+        }
+
+        [Test]
+        public async Task Verify_that_PostEnsureSuccessAsync_with_string_body_sends_body()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.POST));
+                Assert.That(r.Body, Is.EqualTo("post-body"));
+            }, ArgusStatusCode.Created);
+
+            using var client = new ArgusClient(pipeName);
+
+            var response = await client.PostEnsureSuccessAsync("/items", "post-body");
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Created));
+        }
+
+        [Test]
+        public async Task Verify_that_PostEnsureSuccessAsync_with_query_parameters_sends_query_parameters_and_body()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.POST));
+                Assert.That(r.QueryParameters["key"], Is.EqualTo("value"));
+                Assert.That(r.Body, Is.EqualTo("post-body"));
+            }, ArgusStatusCode.Created);
+
+            using var client = new ArgusClient(pipeName);
+
+            var response = await client.PostEnsureSuccessAsync("/items", new Dictionary<string, string> { { "key", "value" } }, "post-body");
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Created));
+        }
+
+        [Test]
+        public async Task Verify_that_PostEnsureSuccessAsync_with_stream_sends_body_and_content_type()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.POST));
+                Assert.That(r.Headers[ArgusHeaderNames.ContentType], Is.EqualTo("application/json"));
+                Assert.That(r.BodyStream, Is.Not.Null);
+            }, ArgusStatusCode.Created);
+
+            using var client = new ArgusClient(pipeName);
+            using var bodyStream = new MemoryStream(Encoding.UTF8.GetBytes("stream-body"));
+
+            var response = await client.PostEnsureSuccessAsync("/items", bodyStream, "application/json");
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Created));
+        }
+
+        [Test]
+        public async Task Verify_that_PutEnsureSuccessAsync_with_string_body_sends_body()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.PUT));
+                Assert.That(r.Body, Is.EqualTo("put-body"));
+            }, ArgusStatusCode.Ok);
+
+            using var client = new ArgusClient(pipeName);
+
+            var response = await client.PutEnsureSuccessAsync("/items", "put-body");
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
+        }
+
+        [Test]
+        public async Task Verify_that_PutEnsureSuccessAsync_with_query_parameters_sends_query_parameters_and_body()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.PUT));
+                Assert.That(r.QueryParameters["key"], Is.EqualTo("value"));
+                Assert.That(r.Body, Is.EqualTo("put-body"));
+            }, ArgusStatusCode.Ok);
+
+            using var client = new ArgusClient(pipeName);
+
+            var response = await client.PutEnsureSuccessAsync("/items", new Dictionary<string, string> { { "key", "value" } }, "put-body");
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
+        }
+
+        [Test]
+        public async Task Verify_that_PutEnsureSuccessAsync_with_stream_sends_body_without_explicit_content_type()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.PUT));
+                Assert.That(r.BodyStream, Is.Not.Null);
+            }, ArgusStatusCode.Ok);
+
+            using var client = new ArgusClient(pipeName);
+            using var bodyStream = new MemoryStream(Encoding.UTF8.GetBytes("stream-body"));
+
+            var response = await client.PutEnsureSuccessAsync("/items", bodyStream);
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
+        }
+
+        [Test]
+        public async Task Verify_that_PatchEnsureSuccessAsync_with_string_body_sends_body()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.PATCH));
+                Assert.That(r.Body, Is.EqualTo("patch-body"));
+            }, ArgusStatusCode.Ok);
+
+            using var client = new ArgusClient(pipeName);
+
+            var response = await client.PatchEnsureSuccessAsync("/items", "patch-body");
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
+        }
+
+        [Test]
+        public async Task Verify_that_PatchEnsureSuccessAsync_with_query_parameters_sends_query_parameters_and_body()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.PATCH));
+                Assert.That(r.QueryParameters["key"], Is.EqualTo("value"));
+                Assert.That(r.Body, Is.EqualTo("patch-body"));
+            }, ArgusStatusCode.Ok);
+
+            using var client = new ArgusClient(pipeName);
+
+            var response = await client.PatchEnsureSuccessAsync("/items", new Dictionary<string, string> { { "key", "value" } }, "patch-body");
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
+        }
+
+        [Test]
+        public async Task Verify_that_PatchEnsureSuccessAsync_with_stream_sends_body_and_content_type()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.PATCH));
+                Assert.That(r.Headers[ArgusHeaderNames.ContentType], Is.EqualTo("text/plain"));
+                Assert.That(r.BodyStream, Is.Not.Null);
+            }, ArgusStatusCode.Ok);
+
+            using var client = new ArgusClient(pipeName);
+            using var bodyStream = new MemoryStream(Encoding.UTF8.GetBytes("stream-body"));
+
+            var response = await client.PatchEnsureSuccessAsync("/items", bodyStream, "text/plain");
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
+        }
+
+        [Test]
+        public async Task Verify_that_DeleteEnsureSuccessAsync_sends_DELETE()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.DELETE));
+                Assert.That(r.Route, Is.EqualTo("/items"));
+            }, ArgusStatusCode.Ok);
+
+            using var client = new ArgusClient(pipeName);
+
+            var response = await client.DeleteEnsureSuccessAsync("/items");
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
+        }
+
+        [Test]
+        public async Task Verify_that_DeleteEnsureSuccessAsync_with_query_parameters_sends_query_parameters()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.DELETE));
+                Assert.That(r.QueryParameters["key"], Is.EqualTo("value"));
+            }, ArgusStatusCode.Ok);
+
+            using var client = new ArgusClient(pipeName);
+
+            var response = await client.DeleteEnsureSuccessAsync("/items", new Dictionary<string, string> { { "key", "value" } });
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
+        }
+
+        [Test]
+        public async Task Verify_that_HeadEnsureSuccessAsync_sends_HEAD()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.HEAD));
+                Assert.That(r.Route, Is.EqualTo("/items"));
+            }, ArgusStatusCode.Ok);
+
+            using var client = new ArgusClient(pipeName);
+
+            var response = await client.HeadEnsureSuccessAsync("/items");
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
+        }
+
+        [Test]
+        public async Task Verify_that_HeadEnsureSuccessAsync_with_query_parameters_sends_query_parameters()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var serverTask = this.RunFakeServerAsync(pipeName, r =>
+            {
+                Assert.That(r.Verb, Is.EqualTo(ArgusVerb.HEAD));
+                Assert.That(r.QueryParameters["key"], Is.EqualTo("value"));
+            }, ArgusStatusCode.Ok);
+
+            using var client = new ArgusClient(pipeName);
+
+            var response = await client.HeadEnsureSuccessAsync("/items", new Dictionary<string, string> { { "key", "value" } });
+
+            await serverTask;
+            Assert.That(response.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
         }
 
         [Test]

--- a/ArgusTransfer.Tests/Client/ArgusClientTestFixture.cs
+++ b/ArgusTransfer.Tests/Client/ArgusClientTestFixture.cs
@@ -738,5 +738,133 @@ namespace ArgusTransfer.Tests.Client
             Assert.That(exception.ReasonPhrase, Is.EqualTo(ArgusStatusCode.NotFound.ToReasonPhrase()));
             Assert.That(exception.ResponseBody, Is.EqualTo("missing"));
         }
+
+        [Test]
+        public async Task Verify_that_PostAsync_with_stream_sends_body_and_content_type()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var payload = "stream-post-payload";
+
+            var serverTask = Task.Run(async () =>
+            {
+                using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut);
+                await server.WaitForConnectionAsync();
+
+                var reader = new StreamReader(server, new UTF8Encoding(false));
+                var writer = new StreamWriter(server, new UTF8Encoding(false)) { AutoFlush = false };
+
+                var request = await this.requestSerializer.ReadAsync(reader, CancellationToken.None);
+
+                Assert.That(request.Verb, Is.EqualTo(ArgusVerb.POST));
+                Assert.That(request.Headers[ArgusHeaderNames.ContentType], Is.EqualTo("application/json"));
+                Assert.That(request.BodyStream, Is.Not.Null);
+
+                using var bodyReader = new StreamReader(request.BodyStream, new UTF8Encoding(false));
+                var receivedBody = await bodyReader.ReadToEndAsync();
+                Assert.That(receivedBody, Is.EqualTo(payload));
+
+                var response = new ArgusResponse
+                {
+                    CorrelationToken = request.CorrelationToken,
+                    StatusCode = ArgusStatusCode.Created
+                };
+
+                this.responseSerializer.Write(writer, response);
+            });
+
+            using var client = new ArgusClient(pipeName);
+            using var bodyStream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+
+            var clientResponse = await client.PostAsync("/upload", bodyStream, "application/json");
+
+            await serverTask;
+
+            Assert.That(clientResponse.StatusCode, Is.EqualTo(ArgusStatusCode.Created));
+        }
+
+        [Test]
+        public async Task Verify_that_PutAsync_with_stream_sends_body_without_explicit_content_type()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var payload = "stream-put-payload";
+
+            var serverTask = Task.Run(async () =>
+            {
+                using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut);
+                await server.WaitForConnectionAsync();
+
+                var reader = new StreamReader(server, new UTF8Encoding(false));
+                var writer = new StreamWriter(server, new UTF8Encoding(false)) { AutoFlush = false };
+
+                var request = await this.requestSerializer.ReadAsync(reader, CancellationToken.None);
+
+                Assert.That(request.Verb, Is.EqualTo(ArgusVerb.PUT));
+                Assert.That(request.BodyStream, Is.Not.Null);
+
+                using var bodyReader = new StreamReader(request.BodyStream, new UTF8Encoding(false));
+                var receivedBody = await bodyReader.ReadToEndAsync();
+                Assert.That(receivedBody, Is.EqualTo(payload));
+
+                var response = new ArgusResponse
+                {
+                    CorrelationToken = request.CorrelationToken,
+                    StatusCode = ArgusStatusCode.Ok
+                };
+
+                this.responseSerializer.Write(writer, response);
+            });
+
+            using var client = new ArgusClient(pipeName);
+            using var bodyStream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+
+            var clientResponse = await client.PutAsync("/upload", bodyStream);
+
+            await serverTask;
+
+            Assert.That(clientResponse.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
+        }
+
+        [Test]
+        public async Task Verify_that_PatchAsync_with_stream_sends_body_and_content_type()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+            var payload = "stream-patch-payload";
+
+            var serverTask = Task.Run(async () =>
+            {
+                using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut);
+                await server.WaitForConnectionAsync();
+
+                var reader = new StreamReader(server, new UTF8Encoding(false));
+                var writer = new StreamWriter(server, new UTF8Encoding(false)) { AutoFlush = false };
+
+                var request = await this.requestSerializer.ReadAsync(reader, CancellationToken.None);
+
+                Assert.That(request.Verb, Is.EqualTo(ArgusVerb.PATCH));
+                Assert.That(request.Headers[ArgusHeaderNames.ContentType], Is.EqualTo("text/plain"));
+                Assert.That(request.BodyStream, Is.Not.Null);
+
+                using var bodyReader = new StreamReader(request.BodyStream, new UTF8Encoding(false));
+                var receivedBody = await bodyReader.ReadToEndAsync();
+                Assert.That(receivedBody, Is.EqualTo(payload));
+
+                var response = new ArgusResponse
+                {
+                    CorrelationToken = request.CorrelationToken,
+                    StatusCode = ArgusStatusCode.Ok
+                };
+
+                this.responseSerializer.Write(writer, response);
+            });
+
+            using var client = new ArgusClient(pipeName);
+            using var bodyStream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+
+            var clientResponse = await client.PatchAsync("/upload", bodyStream, "text/plain");
+
+            await serverTask;
+
+            Assert.That(clientResponse.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
+        }
     }
 }

--- a/ArgusTransfer.Tests/Client/ArgusClientTestFixture.cs
+++ b/ArgusTransfer.Tests/Client/ArgusClientTestFixture.cs
@@ -664,5 +664,79 @@ namespace ArgusTransfer.Tests.Client
 
             Assert.Pass();
         }
+
+        [Test]
+        public async Task Verify_that_GetEnsureSuccessAsync_returns_response_when_status_is_2xx()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+
+            var serverTask = Task.Run(async () =>
+            {
+                using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut);
+                await server.WaitForConnectionAsync();
+
+                var reader = new StreamReader(server, new UTF8Encoding(false));
+                var writer = new StreamWriter(server, new UTF8Encoding(false)) { AutoFlush = false };
+
+                var request = await this.requestSerializer.ReadAsync(reader, CancellationToken.None);
+
+                var response = new ArgusResponse
+                {
+                    CorrelationToken = request.CorrelationToken,
+                    StatusCode = ArgusStatusCode.Ok,
+                    Body = "ok"
+                };
+
+                this.responseSerializer.Write(writer, response);
+            });
+
+            using var client = new ArgusClient(pipeName);
+
+            var clientResponse = await client.GetEnsureSuccessAsync("/healthendpoint");
+
+            await serverTask;
+
+            Assert.That(clientResponse.StatusCode, Is.EqualTo(ArgusStatusCode.Ok));
+            Assert.That(clientResponse.Body, Is.EqualTo("ok"));
+        }
+
+        [Test]
+        public void Verify_that_GetEnsureSuccessAsync_throws_when_status_is_not_2xx()
+        {
+            var pipeName = $"argus-test-{Guid.NewGuid()}";
+
+            var serverTask = Task.Run(async () =>
+            {
+                using var server = new NamedPipeServerStream(pipeName, PipeDirection.InOut);
+                await server.WaitForConnectionAsync();
+
+                var reader = new StreamReader(server, new UTF8Encoding(false));
+                var writer = new StreamWriter(server, new UTF8Encoding(false)) { AutoFlush = false };
+
+                var request = await this.requestSerializer.ReadAsync(reader, CancellationToken.None);
+
+                var response = new ArgusResponse
+                {
+                    CorrelationToken = request.CorrelationToken,
+                    StatusCode = ArgusStatusCode.NotFound,
+                    Body = "missing"
+                };
+
+                this.responseSerializer.Write(writer, response);
+            });
+
+            using var client = new ArgusClient(pipeName);
+
+            var exception = Assert.ThrowsAsync<ArgusRequestException>(async () =>
+            {
+                await client.GetEnsureSuccessAsync("/healthendpoint");
+            });
+
+            serverTask.GetAwaiter().GetResult();
+
+            Assert.That(exception.StatusCode, Is.EqualTo(ArgusStatusCode.NotFound));
+            Assert.That(exception.ReasonPhrase, Is.EqualTo(ArgusStatusCode.NotFound.ToReasonPhrase()));
+            Assert.That(exception.ResponseBody, Is.EqualTo("missing"));
+        }
     }
 }

--- a/ArgusTransfer.Tests/Protocol/ArgusRequestExceptionTestFixture.cs
+++ b/ArgusTransfer.Tests/Protocol/ArgusRequestExceptionTestFixture.cs
@@ -1,0 +1,87 @@
+// -------------------------------------------------------------------------------------------------
+//   <copyright file="ArgusRequestExceptionTestFixture.cs">
+//
+//     Copyright (c) 2025-2026 Sam Gerené
+//
+//     Licensed under the Apache License, Version 2.0 (the "License");
+//     you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//     Unless required by applicable law or agreed to in writing, softwareUseCases
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+//
+//   </copyright>
+//   ------------------------------------------------------------------------------------------------
+
+namespace ArgusTransfer.Tests.Protocol
+{
+    using System;
+
+    using ArgusTransfer.Protocol;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ArgusRequestException"/> class
+    /// </summary>
+    [TestFixture]
+    public class ArgusRequestExceptionTestFixture
+    {
+        [Test]
+        public void Verify_that_default_constructor_does_not_throw()
+        {
+            Assert.That(() => new ArgusRequestException(), Throws.Nothing);
+        }
+
+        [Test]
+        public void Verify_that_message_constructor_sets_message()
+        {
+            var exception = new ArgusRequestException("boom");
+
+            Assert.That(exception.Message, Is.EqualTo("boom"));
+        }
+
+        [Test]
+        public void Verify_that_message_and_inner_constructor_sets_both()
+        {
+            var inner = new InvalidOperationException("inner");
+
+            var exception = new ArgusRequestException("boom", inner);
+
+            Assert.That(exception.Message, Is.EqualTo("boom"));
+            Assert.That(exception.InnerException, Is.SameAs(inner));
+        }
+
+        [Test]
+        public void Verify_that_response_constructor_populates_all_properties()
+        {
+            var exception = new ArgusRequestException(ArgusStatusCode.NotFound, "Not Found", "missing");
+
+            Assert.That(exception.StatusCode, Is.EqualTo(ArgusStatusCode.NotFound));
+            Assert.That(exception.ReasonPhrase, Is.EqualTo("Not Found"));
+            Assert.That(exception.ResponseBody, Is.EqualTo("missing"));
+        }
+
+        [Test]
+        public void Verify_that_response_constructor_builds_message_with_status_and_reason()
+        {
+            var exception = new ArgusRequestException(ArgusStatusCode.InternalServerError, "Internal Server Error", null);
+
+            Assert.That(exception.Message, Does.Contain("500"));
+            Assert.That(exception.Message, Does.Contain("Internal Server Error"));
+        }
+
+        [Test]
+        public void Verify_that_response_constructor_accepts_null_body()
+        {
+            var exception = new ArgusRequestException(ArgusStatusCode.NoContent, "No Content", null);
+
+            Assert.That(exception.ResponseBody, Is.Null);
+        }
+    }
+}

--- a/ArgusTransfer.Tests/Protocol/ArgusResponseTestFixture.cs
+++ b/ArgusTransfer.Tests/Protocol/ArgusResponseTestFixture.cs
@@ -1,0 +1,88 @@
+// -------------------------------------------------------------------------------------------------
+//   <copyright file="ArgusResponseTestFixture.cs">
+//
+//     Copyright (c) 2025-2026 Sam Gerené
+//
+//     Licensed under the Apache License, Version 2.0 (the "License");
+//     you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//     Unless required by applicable law or agreed to in writing, softwareUseCases
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+//
+//   </copyright>
+//   ------------------------------------------------------------------------------------------------
+
+namespace ArgusTransfer.Tests.Protocol
+{
+    using ArgusTransfer.Protocol;
+
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Suite of tests for the <see cref="ArgusResponse"/> class
+    /// </summary>
+    [TestFixture]
+    public class ArgusResponseTestFixture
+    {
+        [TestCase(ArgusStatusCode.Ok)]
+        [TestCase(ArgusStatusCode.Created)]
+        [TestCase(ArgusStatusCode.NoContent)]
+        public void Verify_that_EnsureSuccessStatusCode_returns_self_for_2xx(ArgusStatusCode statusCode)
+        {
+            var response = new ArgusResponse { StatusCode = statusCode };
+
+            var result = response.EnsureSuccessStatusCode();
+
+            Assert.That(result, Is.SameAs(response));
+        }
+
+        [TestCase(ArgusStatusCode.BadRequest)]
+        [TestCase(ArgusStatusCode.Unauthorized)]
+        [TestCase(ArgusStatusCode.Forbidden)]
+        [TestCase(ArgusStatusCode.NotFound)]
+        [TestCase(ArgusStatusCode.NotAcceptable)]
+        [TestCase(ArgusStatusCode.Conflict)]
+        [TestCase(ArgusStatusCode.UnprocessableEntity)]
+        [TestCase(ArgusStatusCode.InternalServerError)]
+        [TestCase(ArgusStatusCode.NotImplemented)]
+        [TestCase(ArgusStatusCode.ServiceUnavailable)]
+        public void Verify_that_EnsureSuccessStatusCode_throws_for_non_2xx(ArgusStatusCode statusCode)
+        {
+            var response = new ArgusResponse { StatusCode = statusCode };
+
+            Assert.That(() => response.EnsureSuccessStatusCode(), Throws.TypeOf<ArgusRequestException>());
+        }
+
+        [Test]
+        public void Verify_that_EnsureSuccessStatusCode_populates_exception_with_status_reason_and_body()
+        {
+            var response = new ArgusResponse
+            {
+                StatusCode = ArgusStatusCode.NotFound,
+                Body = "the requested resource is missing"
+            };
+
+            var exception = Assert.Throws<ArgusRequestException>(() => response.EnsureSuccessStatusCode());
+
+            Assert.That(exception.StatusCode, Is.EqualTo(ArgusStatusCode.NotFound));
+            Assert.That(exception.ReasonPhrase, Is.EqualTo(ArgusStatusCode.NotFound.ToReasonPhrase()));
+            Assert.That(exception.ResponseBody, Is.EqualTo("the requested resource is missing"));
+        }
+
+        [Test]
+        public void Verify_that_EnsureSuccessStatusCode_propagates_null_body_to_exception()
+        {
+            var response = new ArgusResponse { StatusCode = ArgusStatusCode.InternalServerError };
+
+            var exception = Assert.Throws<ArgusRequestException>(() => response.EnsureSuccessStatusCode());
+
+            Assert.That(exception.ResponseBody, Is.Null);
+        }
+    }
+}

--- a/ArgusTransfer/Client/ArgusClient.cs
+++ b/ArgusTransfer/Client/ArgusClient.cs
@@ -358,6 +358,249 @@ namespace ArgusTransfer.Client
         }
 
         /// <summary>
+        /// Sends an <see cref="ArgusRequest"/> over the named pipe and validates that the
+        /// <see cref="ArgusResponse"/> indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="request">The <see cref="ArgusRequest"/> to send</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> SendEnsureSuccessAsync(ArgusRequest request, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.SendAsync(request, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a GET request to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> GetEnsureSuccessAsync(string route, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.GetAsync(route, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a GET request to the specified route with query parameters and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="queryParameters">The query parameters to include in the request</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> GetEnsureSuccessAsync(string route, IReadOnlyDictionary<string, string> queryParameters, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.GetAsync(route, queryParameters, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a POST request to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="body">The optional request body</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> PostEnsureSuccessAsync(string route, string body = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.PostAsync(route, body, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a POST request to the specified route with query parameters and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="queryParameters">The query parameters to include in the request</param>
+        /// <param name="body">The optional request body</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> PostEnsureSuccessAsync(string route, IReadOnlyDictionary<string, string> queryParameters, string body = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.PostAsync(route, queryParameters, body, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a POST request with a streaming body to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="bodyStream">The <see cref="Stream"/> containing the request body</param>
+        /// <param name="contentType">The optional content type of the body. Defaults to application/octet-stream</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> PostEnsureSuccessAsync(string route, Stream bodyStream, string contentType = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.PostAsync(route, bodyStream, contentType, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a PUT request to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="body">The optional request body</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> PutEnsureSuccessAsync(string route, string body = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.PutAsync(route, body, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a PUT request to the specified route with query parameters and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="queryParameters">The query parameters to include in the request</param>
+        /// <param name="body">The optional request body</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> PutEnsureSuccessAsync(string route, IReadOnlyDictionary<string, string> queryParameters, string body = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.PutAsync(route, queryParameters, body, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a PUT request with a streaming body to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="bodyStream">The <see cref="Stream"/> containing the request body</param>
+        /// <param name="contentType">The optional content type of the body. Defaults to application/octet-stream</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> PutEnsureSuccessAsync(string route, Stream bodyStream, string contentType = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.PutAsync(route, bodyStream, contentType, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a PATCH request to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="body">The optional request body</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> PatchEnsureSuccessAsync(string route, string body = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.PatchAsync(route, body, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a PATCH request to the specified route with query parameters and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="queryParameters">The query parameters to include in the request</param>
+        /// <param name="body">The optional request body</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> PatchEnsureSuccessAsync(string route, IReadOnlyDictionary<string, string> queryParameters, string body = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.PatchAsync(route, queryParameters, body, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a PATCH request with a streaming body to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="bodyStream">The <see cref="Stream"/> containing the request body</param>
+        /// <param name="contentType">The optional content type of the body. Defaults to application/octet-stream</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> PatchEnsureSuccessAsync(string route, Stream bodyStream, string contentType = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.PatchAsync(route, bodyStream, contentType, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a DELETE request to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> DeleteEnsureSuccessAsync(string route, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.DeleteAsync(route, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a DELETE request to the specified route with query parameters and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="queryParameters">The query parameters to include in the request</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> DeleteEnsureSuccessAsync(string route, IReadOnlyDictionary<string, string> queryParameters, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.DeleteAsync(route, queryParameters, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a HEAD request to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> HeadEnsureSuccessAsync(string route, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.HeadAsync(route, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
+        /// Sends a HEAD request to the specified route with query parameters and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="queryParameters">The query parameters to include in the request</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        public async Task<ArgusResponse> HeadEnsureSuccessAsync(string route, IReadOnlyDictionary<string, string> queryParameters, TimeSpan? timeout = null, CancellationToken cancellationToken = default)
+        {
+            var response = await this.HeadAsync(route, queryParameters, timeout, cancellationToken);
+            return response.EnsureSuccessStatusCode();
+        }
+
+        /// <summary>
         /// Sends a request with a streaming body using the specified verb
         /// </summary>
         private Task<ArgusResponse> SendStreamAsync(ArgusVerb verb, string route, Stream bodyStream, string contentType, TimeSpan? timeout, CancellationToken cancellationToken)

--- a/ArgusTransfer/Client/IArgusClient.cs
+++ b/ArgusTransfer/Client/IArgusClient.cs
@@ -206,5 +206,184 @@ namespace ArgusTransfer.Client
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
         /// <returns>The <see cref="ArgusResponse"/> received from the server</returns>
         Task<ArgusResponse> HeadAsync(string route, IReadOnlyDictionary<string, string> queryParameters, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends an <see cref="ArgusRequest"/> over the named pipe and validates that the
+        /// <see cref="ArgusResponse"/> indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="request">The <see cref="ArgusRequest"/> to send</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> SendEnsureSuccessAsync(ArgusRequest request, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a GET request to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> GetEnsureSuccessAsync(string route, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a GET request to the specified route with query parameters and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="queryParameters">The query parameters to include in the request</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> GetEnsureSuccessAsync(string route, IReadOnlyDictionary<string, string> queryParameters, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a POST request to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="body">The optional request body</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> PostEnsureSuccessAsync(string route, string body = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a POST request to the specified route with query parameters and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="queryParameters">The query parameters to include in the request</param>
+        /// <param name="body">The optional request body</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> PostEnsureSuccessAsync(string route, IReadOnlyDictionary<string, string> queryParameters, string body = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a POST request with a streaming body to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="bodyStream">The <see cref="Stream"/> containing the request body</param>
+        /// <param name="contentType">The optional content type of the body. Defaults to application/octet-stream</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> PostEnsureSuccessAsync(string route, Stream bodyStream, string contentType = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a PUT request to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="body">The optional request body</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> PutEnsureSuccessAsync(string route, string body = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a PUT request to the specified route with query parameters and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="queryParameters">The query parameters to include in the request</param>
+        /// <param name="body">The optional request body</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> PutEnsureSuccessAsync(string route, IReadOnlyDictionary<string, string> queryParameters, string body = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a PUT request with a streaming body to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="bodyStream">The <see cref="Stream"/> containing the request body</param>
+        /// <param name="contentType">The optional content type of the body. Defaults to application/octet-stream</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> PutEnsureSuccessAsync(string route, Stream bodyStream, string contentType = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a PATCH request to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="body">The optional request body</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> PatchEnsureSuccessAsync(string route, string body = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a PATCH request to the specified route with query parameters and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="queryParameters">The query parameters to include in the request</param>
+        /// <param name="body">The optional request body</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> PatchEnsureSuccessAsync(string route, IReadOnlyDictionary<string, string> queryParameters, string body = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a PATCH request with a streaming body to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="bodyStream">The <see cref="Stream"/> containing the request body</param>
+        /// <param name="contentType">The optional content type of the body. Defaults to application/octet-stream</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> PatchEnsureSuccessAsync(string route, Stream bodyStream, string contentType = null, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a DELETE request to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> DeleteEnsureSuccessAsync(string route, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a DELETE request to the specified route with query parameters and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="queryParameters">The query parameters to include in the request</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> DeleteEnsureSuccessAsync(string route, IReadOnlyDictionary<string, string> queryParameters, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a HEAD request to the specified route and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> HeadEnsureSuccessAsync(string route, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends a HEAD request to the specified route with query parameters and validates that the response indicates a successful (2xx) status code
+        /// </summary>
+        /// <param name="route">The route to send the request to</param>
+        /// <param name="queryParameters">The query parameters to include in the request</param>
+        /// <param name="timeout">An optional per-request timeout that overrides <see cref="DefaultTimeout"/></param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to signal cancellation</param>
+        /// <returns>The successful <see cref="ArgusResponse"/> received from the server</returns>
+        /// <exception cref="ArgusRequestException">Thrown when the response status code is outside the 2xx range</exception>
+        Task<ArgusResponse> HeadEnsureSuccessAsync(string route, IReadOnlyDictionary<string, string> queryParameters, TimeSpan? timeout = null, CancellationToken cancellationToken = default);
     }
 }

--- a/ArgusTransfer/Protocol/ArgusRequestException.cs
+++ b/ArgusTransfer/Protocol/ArgusRequestException.cs
@@ -1,0 +1,117 @@
+// -------------------------------------------------------------------------------------------------
+//   <copyright file="ArgusRequestException.cs">
+//
+//     Copyright (c) 2025-2026 Sam Gerené
+//
+//     Licensed under the Apache License, Version 2.0 (the "License");
+//     you may not use this file except in compliance with the License.
+//     You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//     Unless required by applicable law or agreed to in writing, softwareUseCases
+//     distributed under the License is distributed on an "AS IS" BASIS,
+//     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//     See the License for the specific language governing permissions and
+//     limitations under the License.
+//
+//   </copyright>
+//   ------------------------------------------------------------------------------------------------
+
+namespace ArgusTransfer.Protocol
+{
+    using System;
+
+    /// <summary>
+    /// Represents an error raised when an <see cref="ArgusResponse"/> indicates a non-success status code
+    /// </summary>
+    public class ArgusRequestException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArgusRequestException"/> class
+        /// </summary>
+        public ArgusRequestException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArgusRequestException"/> class
+        /// with the specified error message
+        /// </summary>
+        /// <param name="message">
+        /// The message that describes the error
+        /// </param>
+        public ArgusRequestException(string message)
+            : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArgusRequestException"/> class
+        /// with the specified error message and a reference to the inner exception that is the cause of this exception
+        /// </summary>
+        /// <param name="message">
+        /// The message that describes the error
+        /// </param>
+        /// <param name="innerException">
+        /// The exception that is the cause of the current exception
+        /// </param>
+        public ArgusRequestException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ArgusRequestException"/> class
+        /// populated from the details of a non-success <see cref="ArgusResponse"/>
+        /// </summary>
+        /// <param name="statusCode">
+        /// The <see cref="ArgusStatusCode"/> returned by the server
+        /// </param>
+        /// <param name="reasonPhrase">
+        /// The reason phrase associated with <paramref name="statusCode"/>
+        /// </param>
+        /// <param name="responseBody">
+        /// The body of the response, or <c>null</c> if the response had no body
+        /// </param>
+        public ArgusRequestException(ArgusStatusCode statusCode, string reasonPhrase, string responseBody)
+            : base(BuildMessage(statusCode, reasonPhrase))
+        {
+            this.StatusCode = statusCode;
+            this.ReasonPhrase = reasonPhrase;
+            this.ResponseBody = responseBody;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ArgusStatusCode"/> returned by the server
+        /// </summary>
+        public ArgusStatusCode StatusCode { get; }
+
+        /// <summary>
+        /// Gets the reason phrase associated with <see cref="StatusCode"/>
+        /// </summary>
+        public string ReasonPhrase { get; }
+
+        /// <summary>
+        /// Gets the body of the response that triggered the exception, or <c>null</c> if the response had no body
+        /// </summary>
+        public string ResponseBody { get; }
+
+        /// <summary>
+        /// Builds the exception message from a status code and reason phrase
+        /// </summary>
+        /// <param name="statusCode">
+        /// The <see cref="ArgusStatusCode"/> returned by the server
+        /// </param>
+        /// <param name="reasonPhrase">
+        /// The reason phrase associated with <paramref name="statusCode"/>
+        /// </param>
+        /// <returns>
+        /// A human-readable error message
+        /// </returns>
+        private static string BuildMessage(ArgusStatusCode statusCode, string reasonPhrase)
+        {
+            return $"Argus request failed with status code {(int)statusCode} ({reasonPhrase}).";
+        }
+    }
+}

--- a/ArgusTransfer/Protocol/ArgusResponse.cs
+++ b/ArgusTransfer/Protocol/ArgusResponse.cs
@@ -29,5 +29,30 @@ namespace ArgusTransfer.Protocol
         /// Gets or sets the <see cref="ArgusStatusCode"/> indicating the result of the request
         /// </summary>
         public ArgusStatusCode StatusCode { get; set; }
+
+        /// <summary>
+        /// Returns the current <see cref="ArgusResponse"/> if <see cref="StatusCode"/> is in the 2xx range,
+        /// otherwise throws an <see cref="ArgusRequestException"/> populated with the response details
+        /// </summary>
+        /// <returns>
+        /// The current <see cref="ArgusResponse"/> instance, to allow fluent chaining
+        /// </returns>
+        /// <exception cref="ArgusRequestException">
+        /// Thrown when <see cref="StatusCode"/> indicates a non-success result
+        /// </exception>
+        public ArgusResponse EnsureSuccessStatusCode()
+        {
+            var code = (int)this.StatusCode;
+
+            if (code >= 200 && code < 300)
+            {
+                return this;
+            }
+
+            throw new ArgusRequestException(
+                this.StatusCode,
+                this.StatusCode.ToReasonPhrase(),
+                this.Body);
+        }
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Text-based request/response wire format transmitted over named pipes.
 - **Explicit usings**: `ImplicitUsings` is disabled — all `using` directives must be written explicitly.
 - **LangVersion**: `14.0`
 - **Nullable**: `disable` in both `ArgusTransfer` and `ArgusTransfer.Tests`
-- **XML doc comments**: required on all public types and members.
+- **XML doc comments**: required on all public types and members. **Never use `/// <inheritdoc />`** — always write the full `<summary>`, `<param>`, `<returns>`, and `<exception>` blocks on the implementation, even when they duplicate the interface.
 - **License header**: every `.cs` file starts with the Apache-2.0 copyright block.
 
 ## Testing Conventions


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/samgerene/ArgusTransfer/pulls) open
- [x] I have verified that I am following the Argus Health [code style guidelines](https://raw.githubusercontent.com/samgerene/ArgusTransfer/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
add EnsureSuccessStatusCode helper and EnsureSuccessAsync client overloads; fixes #23
  - Add ArgusRequestException with StatusCode, ReasonPhrase, ResponseBody
  - Add ArgusResponse.EnsureSuccessStatusCode() throwing on non-2xx
  - Add 16 *EnsureSuccessAsync overloads on IArgusClient/ArgusClient
  - Document "no <inheritdoc />" rule in CLAUDE.md
  - Cover with new ArgusRequestException, ArgusResponse, and ArgusClient tests

<!-- Thanks for contributing to ArgusTransfer! -->